### PR TITLE
SimpleDemo: Use c11 standard instead of c++14.

### DIFF
--- a/c/SimpleDemo/SConstruct
+++ b/c/SimpleDemo/SConstruct
@@ -29,7 +29,7 @@ if platform == "osx":
     env.Append(LINKFLAGS = ['-arch', 'x86_64'])
 
 if platform == "linux":
-    env.Append(CCFLAGS = ['-fPIC', '-g','-O3', '-std=c++14'])
+    env.Append(CCFLAGS = ['-fPIC', '-g','-O3', '-std=c11'])
 
 if platform == "windows":
     if target == "debug":


### PR DESCRIPTION
GCC didn't like this:
`cc1: warning: command line option '-std=c++14' is valid for C++/ObjC++ but not for C`